### PR TITLE
Fixed PHP boiler plate

### DIFF
--- a/WEBINTERFACE/BETTER/ui.php
+++ b/WEBINTERFACE/BETTER/ui.php
@@ -39,7 +39,9 @@ extract($postVars);
 if (isset($send))
 {
     // open client connection to TCP server
-	$userip = ($_SERVER['X_FORWARDED_FOR']) ? $_SERVER['X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR']; // get actual ip address of user as his id
+    $userip = $_SERVER['REMOTE_ADDR']; // get actual ip address of user as his id. 
+    // To check for proxies you can replace the line above with the code below, but it is easily faked so it's insecure:
+    // $userip = isset($_SERVER['X_FORWARDED_FOR']) ? $_SERVER['X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR'];
 
     $msg = $userip.$null.$bot.$null.$message.$null;
 
@@ -50,6 +52,7 @@ if (isset($send))
     }
 
     // write message to socket server
+    $ret = '';
     fputs($fp,$msg);
     while (!feof($fp))
 	{

--- a/WEBINTERFACE/SIMPLE/index.php
+++ b/WEBINTERFACE/SIMPLE/index.php
@@ -35,7 +35,9 @@ $userprefix = "You: ";
 if($_POST['send'])
 {
     // open client connection to TCP server
-	$userip = ($_SERVER['X_FORWARDED_FOR']) ? $_SERVER['X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR']; // get actual ip address of user as his id
+	$userip = $_SERVER['REMOTE_ADDR']; // get actual ip address of user as his id
+    // To check for proxies you can replace the line above with the code below, but it is easily faked so it's insecure:
+    // $userip = isset($_SERVER['X_FORWARDED_FOR']) ? $_SERVER['X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR'];
 
     $msg=$_POST['message'];
     $message = $userip.$null.$bot.$null.$msg.$null;
@@ -47,6 +49,7 @@ if($_POST['send'])
         trigger_error('Error opening socket',E_USER_ERROR);
     }
     
+    $ret = '';
     fputs($fp,$message); // write message to socket server
     while (!feof($fp))
 	{

--- a/WEBINTERFACE/SPEECH/ui.php
+++ b/WEBINTERFACE/SPEECH/ui.php
@@ -39,7 +39,9 @@ extract($postVars);
 if (isset($send))
 {
     // open client connection to TCP server
-	$userip = ($_SERVER['X_FORWARDED_FOR']) ? $_SERVER['X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR']; // get actual ip address of user as his id
+	$userip = $_SERVER['REMOTE_ADDR']; // get actual ip address of user as his id
+    // To check for proxies you can replace the line above with the code below, but it is easily faked so it's insecure:
+    // $userip = isset($_SERVER['X_FORWARDED_FOR']) ? $_SERVER['X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR'];
 
     $msg = $userip.$null.$bot.$null.$message.$null;
 
@@ -50,6 +52,7 @@ if (isset($send))
     }
 
     // write message to socket server
+    $ret = '';
     fputs($fp,$msg);
     while (!feof($fp))
 	{


### PR DESCRIPTION
Replaced `$userip` with safer version and added `isset` to original proxy version, commenting it as an option. Missing `isset` caused `Undefined index: X_FORWARDED_FOR` PHP error.

Added missing `$ret` declaration. Missing declaration caused `Undefined variable: ret` PHP error