### PR TITLE
Docker build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ echo '/opt/ChatScript/BINARIES/LinuxChatScript64 $@'; \
 } > /entrypoint-chatscript.sh \
 && chmod +x /entrypoint-chatscript.sh
 
+# Declare volumes for mount point directories
+VOLUME ["/opt/ChatScript/USERS/", "/opt/ChatScript/LOGS/"]
+
 # Set runtime properties
 ENV LANG C.UTF-8
 EXPOSE 1024

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM ubuntu:18.04
 
 # Install system packages/dependencies
-RUN apt-get --yes update && apt-get --no-install-recommends --yes install libcurl3
-
-# Purge apt cache to to reduce image size
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get --yes update \
+ && apt-get --no-install-recommends --yes install libcurl3 \
+ && rm -rf /var/lib/apt/lists/*
 
 # Copy minimal set of ChatScript files
 COPY ./BINARIES/LinuxChatScript64 /opt/ChatScript/BINARIES/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:18.04
+
+# Install system packages/dependencies
+RUN apt-get --yes update && apt-get --no-install-recommends --yes install libcurl3
+
+# Purge apt cache to to reduce image size
+RUN rm -rf /var/lib/apt/lists/*
+
+# Copy minimal set of ChatScript files
+COPY ./BINARIES/LinuxChatScript64 /opt/ChatScript/BINARIES/
+COPY ./DICT/ENGLISH/*.bin /opt/ChatScript/DICT/ENGLISH/
+COPY ./LIVEDATA/SYSTEM /opt/ChatScript/LIVEDATA/SYSTEM
+COPY ./LIVEDATA/ENGLISH /opt/ChatScript/LIVEDATA/ENGLISH
+COPY ./TOPIC/BUILD0 /opt/ChatScript/TOPIC/BUILD0
+
+# Make binary executable
+RUN chmod +x /opt/ChatScript/BINARIES/LinuxChatScript64
+
+# Create entrypoint script so we can pass args and Ctrl+C out
+RUN { \
+echo '#!/bin/bash'; \
+echo 'set -e'; \
+echo '/opt/ChatScript/BINARIES/LinuxChatScript64 $@'; \
+} > /entrypoint-chatscript.sh \
+&& chmod +x /entrypoint-chatscript.sh
+
+# Set runtime properties
+ENV LANG C.UTF-8
+EXPOSE 1024
+WORKDIR /opt/ChatScript/BINARIES
+ENTRYPOINT ["/entrypoint-chatscript.sh"]

--- a/README.md
+++ b/README.md
@@ -174,6 +174,43 @@ The result will go in the `BINARIES` directory.
 On Linux, go stand in the SRC directory and type `make server` (assuming you have make and g++ installed). This creates BINARIES/ChatScript, which can run as a server or locally. There are other make choices for installing PostGres or Mongo.
 
 
+## Docker image
+
+### Building the base Docker image
+
+The `Dockerfile` in this repository provides a ChatScript server with no bots. To build and run it, run the following commands:
+
+```
+docker build -t chatscript .
+docker run -it -p 1024:1024 chatscript
+```
+
+Note: You will probably want to replace the image tag `chatscript` with a more meaningful one for your purposes.
+
+### Building a Docker image containing bot data
+
+Adding bot data to the base image above is as simple as writing a `Dockerfile` like the following one, which builds the `Harry` bot:
+
+```
+FROM chatscript
+
+# Copy raw data needed for Harry
+COPY ./RAWDATA/filesHarry.txt
+COPY ./RAWDATA/HARRY /opt/ChatScript/RAWDATA/HARRY
+COPY ./RAWDATA/QUIBBLE /opt/ChatScript/RAWDATA/QUIBBLE
+
+# Build Harry
+RUN /opt/ChatScript/BINARIES/LinuxChatScript64 local build1=filesHarry.txt
+```
+
+This `Dockerfile` can then be built and run in the same manner as the base `chatscript` image:
+
+```
+docker build -t chatscript-harry .
+docker run -it chatscript-harry local
+```
+
+
 # Full Documentation
 
 [ChatScript Wiki (user guides, tutorials, papers)](/WIKI/README.md)


### PR DESCRIPTION
Adds a `Dockerfile` that can be used to run ChatScript in a Docker container, along with some brief instructions on how to build and run the image.

This would make ChatScript easily deployable to any cloud service. The resultant image size is around 60MB compressed (down from ~1GB), so this should also address issues #25 and #26.

We are currently hosting this image on Docker Hub [here](https://hub.docker.com/r/a2i2/chatscript), but it would be fantastic if there was an official repository. I can help set this up if you like. Once done, new tags on this repository would automatically build a new image on Docker Hub.