### PR TITLE
Fix crash on Win

### DIFF
--- a/SRC/tokenSystem.cpp
+++ b/SRC/tokenSystem.cpp
@@ -955,7 +955,7 @@ static char* FindWordEnd(char* ptr, char* priorToken, char** words, int &count, 
 		if (W && (W->properties & PART_OF_SPEECH || W->systemFlags & PATTERN_WORD))  return stopper; // recognize word at more splits
 	}
 	int lsize = strlen(token);
-	while (IsPunctuation(token[lsize-1])) token[--lsize] = 0; // remove trailing punctuation
+	while (lsize && IsPunctuation(token[lsize-1])) token[--lsize] = 0; // remove trailing punctuation
 	char* after = start + lsize;
 	// see if we have 25,2015
 	size_t tokenlen = strlen(token);


### PR DESCRIPTION
I encountered the issue almost 2.5 years ago (back then it was the old *repo* and the line number was *749*).

It worked fine on several *Lnx* distributions (desktop and mobile), but on *Win* (my laptop, built with *Visual Studio 2015 (Community)*), it crashed almost every time (not sure if we tested it on another *Win*).

The problem at its core was that *lsize* was becoming ***0***, and then an invalid memory address was being referenced, generating *Undefined Behavior*.

I don't remember the details (in theory, an empty *token* could generate that;  but I no longer have the environment to reproduce it), and more important, I can't imagine why it was only reproducible in my case, but this fixed it.
