### PR TITLE
Docs fixes

### DIFF
--- a/WIKI/ChatScript-Advanced-Concept-Manual.md
+++ b/WIKI/ChatScript-Advanced-Concept-Manual.md
@@ -179,8 +179,6 @@ The above detects a pattern, records the location start and end of it so
 that you can then mark where in the sentence ~myconcept will now be detected
 by any future patterns of yours.
 
-<<<<<<< HEAD
-
 ## Performance
 
 Using concepts in patterns is "free", as is 
@@ -195,5 +193,3 @@ runs linear with number of concept members, so it should be avoided for large
 concepts. Pattern matching with concepts/match_variables has all its overhead
 cost paid for during marking so there is no real cost later. And that marking overhead is
 trivial.
-=======
->>>>>>> 64d7d51a5e09623a04d749a68f2b39584e181144

--- a/WIKI/ChatScript-Basic-User-Manual.md
+++ b/WIKI/ChatScript-Basic-User-Manual.md
@@ -785,12 +785,7 @@ _sure_ and _I am sure_ are different.
 
 Words that have a different meaning at the start of a sentence are commonly called interjections. 
 
-<<<<<<< HEAD
-In ChatScript these are defined by the `LIVEDATA/ENGLISH/SUBSTITUTES/interjections.txt` file 
-=======
-In ChatScript these are defined by the `interjections.txt` file (for English language, see [interjections.txt](../LIVEDATA/ENGLISH/SUBSTITUTES/interjections.txt)). 
->>>>>>> 64d7d51a5e09623a04d749a68f2b39584e181144
-Also there are some in the `texting.txt` file.
+In ChatScript these are defined by the `interjections.txt` file (for English language, see [interjections.txt](../LIVEDATA/ENGLISH/SUBSTITUTES/interjections.txt)). Also there are some in the `texting.txt` file.
 
 In addition, the file augments this concept with _discourse acts_, phrases that are like an interjection. 
 All interjections and discourse acts map to concept sets, which either come through as the user input instead of what they wrote or
@@ -804,29 +799,17 @@ sentence, followed by _I will go_ as a new sentence.
 These generic interjections (which are open to author control via `interjections.txt`) are listed
 in the [ChatScript System Variables and Engine-defined Concepts](ChatScript-System-Variables-and-Engine-defined-Concepts.md) manual. 
 
-<<<<<<< HEAD
 If  interjections at the start of a sentence are broken off into their own sentence (as they used to be by default but are no longer),
-=======
-If  interjections at the start of a sentence are broken off into their own sentence (as they are by default -- you can block this),
->>>>>>> 64d7d51a5e09623a04d749a68f2b39584e181144
 this kind of pattern does not work:
 
     u: ( ~yes _* )
 
 You cannot capture the rest of the sentence here, because it will be part of the next
-<<<<<<< HEAD
-sentence instead. This means interjections can act somewhat differently from other concepts.
-If you use a word in a pattern which may get remapped on input, the script compiler will
-issue a warning. Likely you should use the remapped name instead. 
-
-But you can turn off this behavior and then the above pattern works perfectly well. By default it is off.
-=======
 sentence instead. This means interjections act somewhat differently from other concepts.
 If you use a word in a pattern which may get remapped on input, the script compiler will
 issue a warning. Likely you should use the remapped name instead. 
 
 But you can turn off this behavior and then the above pattern works perfectly well.
->>>>>>> 64d7d51a5e09623a04d749a68f2b39584e181144
 
 ## Canonization
 
@@ -887,11 +870,7 @@ anywhere in the sentence at all:
     u: ( !~negativeWords I * ~like * ~meat ) You like meat. 
 
 
-<<<<<<< HEAD
-While `!` checks for the entire rest of the sentence, `!!` checks just the next word from where you are. So
-=======
 While `!` Checks for the entire rest of the sentence, `!!` checks just the next word from where you are. So
->>>>>>> 64d7d51a5e09623a04d749a68f2b39584e181144
 
     u: ( test !!this)  I win
 
@@ -1212,11 +1191,7 @@ You can also directly test a variable to see if it has a particular value using 
 test in the pattern. Relational tests use no whitespace, they are all one big token. One
 such relation is `=`, also writeable as `==`.
 
-<<<<<<< HEAD
     ?: ( $gender=male I like boys ) That's less controversial these days.
-=======
-    ?: ( $gender=male I like boys ) Oh, dear.
->>>>>>> 64d7d51a5e09623a04d749a68f2b39584e181144
 
 Here, the rule will only start checking for input matches if `$gender` has the value male
 (case insensitive). If it is not defined or has any other value, this rule fails immediately.

--- a/WIKI/ChatScript-Fact-Manual.md
+++ b/WIKI/ChatScript-Fact-Manual.md
@@ -500,7 +500,7 @@ Still it's tedious to put in the well mannered *. So there is one other thing yo
 You can make a tab table, where tab characters are automatically convered into space-separated * values instead of being
 ignored white space.
 table: ^mytable TAB ($_arg1 $_arg2 $_arg3 )
-...
+```
 DATA:
 Location
     Japan   

--- a/WIKI/ChatScript-Fact-Manual.md
+++ b/WIKI/ChatScript-Fact-Manual.md
@@ -499,8 +499,8 @@ Where * means use the last seen value from prior entries (you write your table t
 Still it's tedious to put in the well mannered *. So there is one other thing you can do.
 You can make a tab table, where tab characters are automatically convered into space-separated * values instead of being
 ignored white space.
-table: ^mytable TAB ($_arg1 $_arg2 $_arg3 )
 ```
+table: ^mytable TAB ($_arg1 $_arg2 $_arg3 )
 DATA:
 Location
     Japan   

--- a/WIKI/ChatScript-Json.md
+++ b/WIKI/ChatScript-Json.md
@@ -106,6 +106,7 @@ Such a structure might be composed of these facts:
 (ja-5 2 Paula)
 ```
 This would correspond to a JSON string that looks like this:
+```
 [ "Robert", "Terry", "Paula"]
 ```
 

--- a/WIKI/ESOTERIC-CHATSCRIPT/ChatScript-Engine.md
+++ b/WIKI/ESOTERIC-CHATSCRIPT/ChatScript-Engine.md
@@ -613,7 +613,6 @@ _four_score_and_seven_years_ago_ which is marked as a number and whose canonical
 Dialog acts can be split into separate sentences so that _Yes I love you_ and _Yes, I love you_ and _Yes. I love
 you_ all become the same input of two sentences - the dialog act `~yes` and _I love you_. 
 
-<<<<<<< HEAD
 Run together words may be split if the composite is not known and the pieces are.
 
 ## Pos-parsing
@@ -703,8 +702,6 @@ You must enable the `PRIVATE_CODE` define.
 
 Inside it you place files:
 
-=======
->>>>>>> 64d7d51a5e09623a04d749a68f2b39584e181144
 `privatesrc.cpp`: code you want to add to functionexecute.cpp (your own cs engine functions)
 classic definitions compatible with invocation from script look like this:
 ```
@@ -740,16 +737,11 @@ Debug table entries like this:
 # Code Zones
 ![ChatScript architecture](arch.png)
 
-<<<<<<< HEAD
 The system is divided into the code zones shown below. All code is in SRC.
-=======
-The system is divided into the code zones shown above. All code is in SRC.
->>>>>>> 64d7d51a5e09623a04d749a68f2b39584e181144
 
 ## Core Engine
 * `dictionary` is `dictionary`
 * `facts/JSON queries` is `factSystem`, `json`, `jsmn`, and * * * `infer`
-<<<<<<< HEAD
 * `long term user memory` is `userCache`, `userSystem`
 * `topics` and loading the results of compilation is `topicSystem`
 * `functions` is `functionExecute`
@@ -757,17 +749,7 @@ The system is divided into the code zones shown above. All code is in SRC.
 * `JavaScript` is `javascript`
 * `memory allocation` and other things like file system access is in `os`
 * `output eval` is `outputSystem`
-=======
-* `long term memory` is `userCache`, `userSystem`
-* `topics` is `topicSystem`
-* `functions` is `functionExecute`
-* `variables` is `variableSystem` and `systemVariables`
-* `JavaScript` is `javascript`
-* `memory allocation` is `os`
-* `output eval` is `outputSystem`
 * `os access` is `os`
->>>>>>> 64d7d51a5e09623a04d749a68f2b39584e181144
-
 * folders inside SRC are external systems included in CS, including:
 ```
 * curl (web api handling)
@@ -783,15 +765,6 @@ The system is divided into the code zones shown above. All code is in SRC.
 
 ## External Access
 * `OOB` is partly in `tokenSystem` and mostly in `mainSystem`
-<<<<<<< HEAD
-* `Mongo` is `mongodb`
-* `Postgres` is `postgres`
-* All of the system's `^functions` are in `functionExecute`
-* Servers are `evserver`, `cs_ev` and `csocket`
-
-## World Model
-* Natural language abilities are in `english`, `englishTagger`, `markSystem`, `patternSystem`, `spellcheck`, `tagger` and LIVEDATA and DICT
-=======
 * `Mongo` is `mongodb.cpp`
 * `Postgres` is `postgres`
 * All of the `^functions` are in `functionExecute`
@@ -799,7 +772,6 @@ The system is divided into the code zones shown above. All code is in SRC.
 
 ## World Model
 * Natural language abilities are in `english.cpp`, `englishTagger`, `markSystem`, `patternSystem`, `spellcheck`, `tagger` and LIVEDATA and DICT
->>>>>>> 64d7d51a5e09623a04d749a68f2b39584e181144
 * RAWDATA/ONTOLOGY contains ontology data
 * RAWDATA/WORLDDATA contains world data
 

--- a/WIKI/ESOTERIC-CHATSCRIPT/ChatScript-PostgreSQL.md
+++ b/WIKI/ESOTERIC-CHATSCRIPT/ChatScript-PostgreSQL.md
@@ -279,7 +279,6 @@ psql
 ```
 which is a tool to log into the server. You may have to be logged in as postgres.
 There's a bunch more about setting up login passwords, etc. RTFM.
-<<<<<<< HEAD
 
 # WARNINGS about characters from a user:
 Be careful about allowing the special characters / and \ .
@@ -290,5 +289,3 @@ The Postgres CS database schema definition for your user data field value is byt
 You will need to modify the Postgres cs code and database definition.
 I would stay away from using any reference of / and \ in anything that might make it to your user files. 
 Actually, I would scan all of your code and get rid of anything that uses these characters.
-=======
->>>>>>> 64d7d51a5e09623a04d749a68f2b39584e181144


### PR DESCRIPTION
While exploring the docs I've stumbled across a few formatting issues, caused either by unresolved merge conflicts or missing codeblock tags. This PR hopefully resolves some of the ones I've found so far (although I have no idea if the merges I've selected to resolve the conflicts are the correct ones - I've typically chosen the more wordier versions)